### PR TITLE
chore: add integration header to apify requests

### DIFF
--- a/src/main/java/io/kestra/plugin/apify/ApifyConnection.java
+++ b/src/main/java/io/kestra/plugin/apify/ApifyConnection.java
@@ -44,6 +44,8 @@ public abstract class ApifyConnection extends Task implements ApifyConnectionInt
     protected final static ObjectMapper mapper = JacksonMapper.ofJson(false);
     private static final String APIFY_API_URL = "https://api.apify.com/v2";
     private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+    protected static final String INTEGRATION_VALUE = "kestra";
+    protected static final String INTEGRATION_HEADER = "x-apify-integration-platform";
 
     @NotNull
     private Property<String> apiToken;
@@ -123,7 +125,7 @@ public abstract class ApifyConnection extends Task implements ApifyConnectionInt
      * Creates a GET request builder with authentication and headers
      */
     protected HttpRequest.HttpRequestBuilder buildGetRequest(String url) {
-        return HttpRequest.builder()
+        return getBaseHttpRequestBuilder()
             .uri(URI.create(getBaseUrl() + "/" + url))
             .method("GET");
     }
@@ -134,7 +136,7 @@ public abstract class ApifyConnection extends Task implements ApifyConnectionInt
     protected HttpRequest.HttpRequestBuilder buildPostRequest(String url, Object body) throws Exception {
         String jsonBody = mapper.writeValueAsString(body);
 
-        return HttpRequest.builder()
+        return getBaseHttpRequestBuilder()
             .uri(URI.create(getBaseUrl() + "/" + url))
             .method("POST")
             .body(HttpRequest.StringRequestBody.builder().content(jsonBody).build());
@@ -146,7 +148,7 @@ public abstract class ApifyConnection extends Task implements ApifyConnectionInt
     protected HttpRequest.HttpRequestBuilder buildPatchRequest(String url, Object body) throws Exception {
         String jsonBody = mapper.writeValueAsString(body);
 
-        return HttpRequest.builder()
+        return getBaseHttpRequestBuilder()
             .uri(URI.create(getBaseUrl() + "/" + url))
             .method("PATCH")
             .body(HttpRequest.StringRequestBody.builder().content(jsonBody).build());
@@ -156,9 +158,13 @@ public abstract class ApifyConnection extends Task implements ApifyConnectionInt
      * Creates a DELETE request builder with authentication and headers
      */
     protected HttpRequest.HttpRequestBuilder buildDeleteRequest(String url)  {
-        return HttpRequest.builder()
+        return getBaseHttpRequestBuilder()
             .uri(URI.create(getBaseUrl() + "/" + url))
             .method("DELETE");
+    }
+
+    private static HttpRequest.HttpRequestBuilder getBaseHttpRequestBuilder() {
+        return HttpRequest.builder().addHeader(INTEGRATION_HEADER, INTEGRATION_VALUE);
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/apify/ApifyConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/apify/ApifyConnectionTest.java
@@ -1,0 +1,36 @@
+package io.kestra.plugin.apify;
+
+import io.kestra.core.http.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import static io.kestra.plugin.apify.ApifyConnection.INTEGRATION_HEADER;
+import static io.kestra.plugin.apify.ApifyConnection.INTEGRATION_VALUE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApifyConnectionTest {
+    ApifyConnection apifyConnection = new ApifyConnection(){};
+
+    @Test
+    void givenGetRequest_whenBuilt_thenIncludesIntegrationPlatformHeader() {
+        verifyHttpRequestIncludesPlatformHeader(apifyConnection.buildGetRequest("https://example.com"));
+    }
+
+    @Test
+    void givenPostRequest_whenBuilt_thenIncludesIntegrationPlatformHeader() throws Exception {
+        verifyHttpRequestIncludesPlatformHeader(apifyConnection.buildPostRequest("https://example.com", null));
+    }
+
+    @Test
+    void givenPatchRequest_whenBuilt_thenIncludesIntegrationPlatformHeader() throws Exception {
+        verifyHttpRequestIncludesPlatformHeader(apifyConnection.buildPatchRequest("https://example.com", null));
+    }
+
+    @Test
+    void givenDeleteRequest_whenBuilt_thenIncludesIntegrationPlatformHeader() {
+        verifyHttpRequestIncludesPlatformHeader(apifyConnection.buildDeleteRequest("https://example.com"));
+    }
+
+    private void verifyHttpRequestIncludesPlatformHeader(HttpRequest.HttpRequestBuilder httpRequest) {
+        assertTrue(httpRequest.build().getHeaders().map().get(INTEGRATION_HEADER).contains(INTEGRATION_VALUE));
+    }
+}


### PR DESCRIPTION
### What changes are being made and why?
As per '[issue:7 Add x-apify-integration-platform header for usage tracking](https://github.com/kestra-io/plugin-apify/issues/7)' we should be adding a header to all requests set to Apify so they can identify requests made by our integration.

---

### How the changes have been QAed?

I've added a few unit tests to verify the behaviour and run the flows bellow as a sanity check that the integration still works.

```yaml
id: run_actor_and_fetch_dataset
namespace: company.team

tasks:
    - id: run_actor
      type: io.kestra.plugin.apify.actor.Run
      actorId: GdWCkxBtKWOsKjdch
      maxItems: 5
      input:
          hashtags: ["fyp"]
      apiToken: "{{secret(namespace=flow.namespace, key='APIFY_API_KEY')}}"
    - id: log_get_last_run_results
      type: io.kestra.plugin.core.log.Log
      message: '{{outputs.run_actor}}'
    - id: get_data_set_raw
      type: io.kestra.plugin.apify.dataset.Get
      datasetId: '{{outputs.run_actor.defaultDatasetId}}'
      apiToken: "{{secret(namespace=flow.namespace, key='APIFY_API_KEY')}}"
    - id: log_get_data_set_raw_results
      type: io.kestra.plugin.core.log.Log
      message: '{{outputs.get_data_set_raw}}'
```
