### PR TITLE
feat: Apify integration improvements (#16)

### DIFF
--- a/src/main/java/io/kestra/plugin/apify/ApifyConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/apify/ApifyConnectionInterface.java
@@ -8,7 +8,8 @@ import io.kestra.core.models.annotations.PluginProperty;
 public interface ApifyConnectionInterface {
     @Schema(
         title = "Apify API token",
-        description = "Personal Apify API token used for all requests; required."
+        description = "Personal Apify API token used for all requests; required.",
+        format = "password"
     )
     @PluginProperty(group = "connection")
     Property<String> getApiToken();

--- a/src/main/java/io/kestra/plugin/apify/actor/MemoryMbytes.java
+++ b/src/main/java/io/kestra/plugin/apify/actor/MemoryMbytes.java
@@ -1,0 +1,26 @@
+package io.kestra.plugin.apify.actor;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MemoryMbytes {
+    MB_128(128),
+    MB_256(256),
+    MB_512(512),
+    MB_1024(1024),
+    MB_2048(2048),
+    MB_4096(4096),
+    MB_8192(8192),
+    MB_16384(16384),
+    MB_32768(32768);
+
+    private final int value;
+
+    MemoryMbytes(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/kestra/plugin/apify/actor/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/actor/Run.java
@@ -17,6 +17,8 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.apify.ApifyConnection;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -112,7 +114,7 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
         description = "Seconds to wait synchronously for the run to complete (0–60); 0 returns immediately with a transitional status if still running. Maximum is 60 seconds."
     )
     @PluginProperty(group = "execution")
-    private Property<Integer> waitForFinish;
+    private Property<@Min(0) @Max(60) Integer> waitForFinish;
 
     @Schema(
         title = "Webhooks",

--- a/src/main/java/io/kestra/plugin/apify/actor/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/actor/Run.java
@@ -109,10 +109,10 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
 
     @Schema(
         title = "Wait for finish (seconds)",
-        description = "Seconds to wait synchronously for completion (0–60); default 0 returns a transitional status if still running."
+        description = "Seconds to wait synchronously for the run to complete (0–60); 0 returns immediately with a transitional status if still running. Maximum is 60 seconds."
     )
     @PluginProperty(group = "execution")
-    private Property<Double> waitForFinish;
+    private Property<Integer> waitForFinish;
 
     @Schema(
         title = "Webhooks",
@@ -136,7 +136,7 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
             "maxItems", runContext.render(this.maxItems).as(Integer.class),
             "maxTotalChargeUsd", runContext.render(this.maxTotalChargeUsd).as(Double.class),
             "build", runContext.render(this.build).as(String.class),
-            "waitForFinish", runContext.render(this.waitForFinish).as(Double.class),
+            "waitForFinish", runContext.render(this.waitForFinish).as(Integer.class),
             "webhooks", runContext.render(this.webhooks).as(String.class)
         );
 

--- a/src/main/java/io/kestra/plugin/apify/actor/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/actor/Run.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -22,7 +23,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -81,10 +81,10 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
 
     @Schema(
         title = "Memory (MB)",
-        description = "Memory limit in megabytes (powers of two, minimum 128); uses actor default when omitted."
+        description = "Memory allocation for the run; must be a power of two between 128 MB and 32768 MB."
     )
     @PluginProperty(group = "execution")
-    private Property<Double> memory;
+    private Property<MemoryMbytes> memory;
 
     @Schema(
         title = "Max items",
@@ -132,7 +132,7 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
         Map<String, Object> rInput = runContext.render(this.input).asMap(String.class, Object.class);
         Map<String, Optional<?>> queryParams = Map.of(
             "timeout", runContext.render(this.requestTimeout).as(Double.class),
-            "memory", runContext.render(this.memory).as(Double.class),
+            "memory", runContext.render(this.memory).as(MemoryMbytes.class).map(MemoryMbytes::getValue),
             "maxItems", runContext.render(this.maxItems).as(Integer.class),
             "maxTotalChargeUsd", runContext.render(this.maxTotalChargeUsd).as(Double.class),
             "build", runContext.render(this.build).as(String.class),

--- a/src/main/java/io/kestra/plugin/apify/dataset/Save.java
+++ b/src/main/java/io/kestra/plugin/apify/dataset/Save.java
@@ -21,6 +21,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.PluginProperty;
 
+@Deprecated
 @SuperBuilder
 @ToString
 @EqualsAndHashCode
@@ -28,7 +29,13 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Schema(
     title = "Save Apify dataset to temp file",
-    description = "Downloads dataset items to Kestra temp storage with short polling and exponential backoff until data appears or the 300s timeout is reached. Retries on empty responses while the actor finishes writing."
+    description = """
+        Deprecated: actors automatically save their output to a dataset, so this task is no longer necessary.
+        Use `dataset.Get` or `dataset.GetLastRun` instead to retrieve the dataset directly after the actor run.
+
+        Downloads dataset items to Kestra temp storage with short polling and exponential backoff until data appears or the 300s timeout is reached.
+        Retries on empty responses while the actor finishes writing.
+        """
 )
 @Plugin(
     examples = {

--- a/src/main/java/io/kestra/plugin/apify/task/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/task/Run.java
@@ -1,0 +1,165 @@
+package io.kestra.plugin.apify.task;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.apify.ApifyConnection;
+import io.kestra.plugin.apify.actor.ActorRun;
+import io.kestra.plugin.apify.actor.ActorRunApiResponseWrapper;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Start an Apify Task run",
+    description = """
+        Triggers an Apify Task (an actor with predefined configuration) with optional input overrides and run caps,
+        adding query parameters only when set. Returns the run detail from Apify.
+        """
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Run an Apify Task by its ID.",
+            full = true,
+            code = """
+                id: run_apify_task
+                namespace: company.team
+
+                tasks:
+                  - id: run_task
+                    type: io.kestra.plugin.apify.task.Run
+                    taskId: my_username~my-task
+                    apiToken: "{{ secret('APIFY_API_TOKEN') }}"
+                """
+        ),
+        @Example(
+            title = "Run an Apify Task with input overrides and a synchronous wait.",
+            full = true,
+            code = """
+                id: run_apify_task_with_input
+                namespace: company.team
+
+                tasks:
+                  - id: run_task
+                    type: io.kestra.plugin.apify.task.Run
+                    taskId: my_username~my-task
+                    apiToken: "{{ secret('APIFY_API_TOKEN') }}"
+                    maxItems: 100
+                    waitForFinish: 60
+                    input:
+                      startUrls:
+                        - url: "https://example.com"
+                """
+        )
+    }
+)
+public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
+    @Schema(
+        title = "Task ID",
+        description = "Apify Task ID or owner~task-name to execute."
+    )
+    @NotNull
+    private Property<String> taskId;
+
+    @Schema(
+        title = "Input",
+        description = "JSON payload to override the task's predefined input; omitted when empty so the task uses its saved input."
+    )
+    private Property<Map<String, Object>> input;
+
+    @Schema(
+        title = "Timeout (seconds)",
+        description = "Actor run timeout override in seconds; falls back to the task's default if unset."
+    )
+    private Property<Double> requestTimeout;
+
+    @Schema(
+        title = "Memory (MB)",
+        description = "Memory limit in megabytes (powers of two, minimum 128); uses task default when omitted."
+    )
+    private Property<Integer> memory;
+
+    @Schema(
+        title = "Max items",
+        description = "Cap number of items returned to control pay-per-result charges."
+    )
+    private Property<Integer> maxItems;
+
+    @Schema(
+        title = "Max total charge (USD)",
+        description = "Maximum allowed cost for the run; stops charges beyond this ceiling."
+    )
+    private Property<Double> maxTotalChargeUsd;
+
+    @Schema(
+        title = "Build",
+        description = "Build tag or number to run; defaults to the actor's configured build (typically latest)."
+    )
+    private Property<String> build;
+
+    @Schema(
+        title = "Wait for finish (seconds)",
+        description = "Seconds to wait synchronously for the run to complete (0–60); 0 returns immediately with a transitional status if still running. Maximum is 60 seconds."
+    )
+    private Property<Integer> waitForFinish;
+
+    @Schema(
+        title = "Webhooks",
+        description = "Base64-encoded JSON array describing webhooks for lifecycle events."
+    )
+    private Property<String> webhooks;
+
+    @Override
+    public ActorRun run(RunContext runContext) throws Exception {
+        var rTaskId = runContext.render(this.taskId).as(String.class).orElseThrow(
+            () -> new IllegalArgumentException("taskId is required")
+        );
+
+        var rInput = runContext.render(this.input).asMap(String.class, Object.class);
+        Map<String, Optional<?>> queryParams = Map.of(
+            "timeout", runContext.render(this.requestTimeout).as(Double.class),
+            "memory", runContext.render(this.memory).as(Integer.class),
+            "maxItems", runContext.render(this.maxItems).as(Integer.class),
+            "maxTotalChargeUsd", runContext.render(this.maxTotalChargeUsd).as(Double.class),
+            "build", runContext.render(this.build).as(String.class),
+            "waitForFinish", runContext.render(this.waitForFinish).as(Integer.class),
+            "webhooks", runContext.render(this.webhooks).as(String.class)
+        );
+
+        var filteredQueryParams = queryParams.entrySet().stream().filter(
+            entry -> entry.getValue().isPresent()
+        ).collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().get()
+            )
+        );
+
+        HttpRequest.HttpRequestBuilder requestBuilder = buildPostRequest(
+            addQueryParams(String.format("actor-tasks/%s/runs", rTaskId), filteredQueryParams),
+            rInput
+        );
+
+        return makeCall(
+            runContext, requestBuilder, ActorRunApiResponseWrapper.class
+        ).getData();
+    }
+}

--- a/src/main/java/io/kestra/plugin/apify/task/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/task/Run.java
@@ -16,6 +16,8 @@ import io.kestra.plugin.apify.actor.ActorRunApiResponseWrapper;
 import io.kestra.plugin.apify.actor.MemoryMbytes;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -120,7 +122,7 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
         title = "Wait for finish (seconds)",
         description = "Seconds to wait synchronously for the run to complete (0–60); 0 returns immediately with a transitional status if still running. Maximum is 60 seconds."
     )
-    private Property<Integer> waitForFinish;
+    private Property<@Min(0) @Max(60) Integer> waitForFinish;
 
     @Schema(
         title = "Webhooks",

--- a/src/main/java/io/kestra/plugin/apify/task/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/task/Run.java
@@ -13,6 +13,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.apify.ApifyConnection;
 import io.kestra.plugin.apify.actor.ActorRun;
 import io.kestra.plugin.apify.actor.ActorRunApiResponseWrapper;
+import io.kestra.plugin.apify.actor.MemoryMbytes;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -93,9 +94,9 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
 
     @Schema(
         title = "Memory (MB)",
-        description = "Memory limit in megabytes (powers of two, minimum 128); uses task default when omitted."
+        description = "Memory allocation for the run; must be a power of two between 128 MB and 32768 MB."
     )
-    private Property<Integer> memory;
+    private Property<MemoryMbytes> memory;
 
     @Schema(
         title = "Max items",
@@ -136,7 +137,7 @@ public class Run extends ApifyConnection implements RunnableTask<ActorRun> {
         var rInput = runContext.render(this.input).asMap(String.class, Object.class);
         Map<String, Optional<?>> queryParams = Map.of(
             "timeout", runContext.render(this.requestTimeout).as(Double.class),
-            "memory", runContext.render(this.memory).as(Integer.class),
+            "memory", runContext.render(this.memory).as(MemoryMbytes.class),
             "maxItems", runContext.render(this.maxItems).as(Integer.class),
             "maxTotalChargeUsd", runContext.render(this.maxTotalChargeUsd).as(Double.class),
             "build", runContext.render(this.build).as(String.class),

--- a/src/main/java/io/kestra/plugin/apify/task/package-info.java
+++ b/src/main/java/io/kestra/plugin/apify/task/package-info.java
@@ -1,0 +1,8 @@
+@PluginSubGroup(
+    title = "Apify Task",
+    description = "This sub-group of plugins contains tasks to interact with Apify Tasks (actors with predefined configuration).",
+    categories = { PluginSubGroup.PluginCategory.DATA }
+)
+package io.kestra.plugin.apify.task;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/test/java/io/kestra/plugin/apify/ApifyConnectionInterfaceTest.java
+++ b/src/test/java/io/kestra/plugin/apify/ApifyConnectionInterfaceTest.java
@@ -1,0 +1,17 @@
+package io.kestra.plugin.apify;
+
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApifyConnectionInterfaceTest {
+
+    @Test
+    void givenApiTokenMethod_whenInspectingSchemaAnnotation_thenFormatIsPassword() throws NoSuchMethodException {
+        var method = ApifyConnectionInterface.class.getMethod("getApiToken");
+        var schema = method.getAnnotation(Schema.class);
+        assertEquals("password", schema.format());
+    }
+}

--- a/src/test/java/io/kestra/plugin/apify/actor/MemoryMbytesTest.java
+++ b/src/test/java/io/kestra/plugin/apify/actor/MemoryMbytesTest.java
@@ -1,0 +1,30 @@
+package io.kestra.plugin.apify.actor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MemoryMbytesTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void givenMemoryMbytesEnum_whenCountingValues_thenHasNineConstants() {
+        assertEquals(9, MemoryMbytes.values().length);
+    }
+
+    @Test
+    void givenMemoryMbytesConstants_whenGettingValue_thenReturnsExpectedInt() {
+        assertEquals(128, MemoryMbytes.MB_128.getValue());
+        assertEquals(32768, MemoryMbytes.MB_32768.getValue());
+    }
+
+    @Test
+    void givenMemoryMbytesEnum_whenSerializingWithJackson_thenProducesExpectedInteger() throws Exception {
+        assertEquals("128", mapper.writeValueAsString(MemoryMbytes.MB_128));
+        assertEquals("256", mapper.writeValueAsString(MemoryMbytes.MB_256));
+        assertEquals("1024", mapper.writeValueAsString(MemoryMbytes.MB_1024));
+        assertEquals("32768", mapper.writeValueAsString(MemoryMbytes.MB_32768));
+    }
+}

--- a/src/test/java/io/kestra/plugin/apify/actor/RunValidationTest.java
+++ b/src/test/java/io/kestra/plugin/apify/actor/RunValidationTest.java
@@ -1,0 +1,38 @@
+package io.kestra.plugin.apify.actor;
+
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that {@code waitForFinish} in {@link Run} declares the expected {@code @Min(0)} and {@code @Max(60)}
+ * constraints as type-use annotations on the generic type parameter {@code Property<@Min(0) @Max(60) Integer>}.
+ */
+class RunValidationTest {
+
+    @Test
+    void givenWaitForFinishField_whenInspectingConstraints_thenMinIsZeroAndMaxIsSixty() throws NoSuchFieldException {
+        Field field = Run.class.getDeclaredField("waitForFinish");
+
+        // The field type is Property<@Min(0) @Max(60) Integer>; the annotation sits on the type argument.
+        AnnotatedType annotatedType = field.getAnnotatedType();
+        AnnotatedType[] typeArguments = ((AnnotatedParameterizedType) annotatedType).getAnnotatedActualTypeArguments();
+        AnnotatedType integerTypeArgument = typeArguments[0];
+
+        Min min = integerTypeArgument.getAnnotation(Min.class);
+        Max max = integerTypeArgument.getAnnotation(Max.class);
+
+        assertNotNull(min, "@Min annotation must be present on waitForFinish type argument");
+        assertNotNull(max, "@Max annotation must be present on waitForFinish type argument");
+        assertEquals(0, min.value(), "@Min value must be 0");
+        assertEquals(60, max.value(), "@Max value must be 60");
+    }
+}

--- a/src/test/java/io/kestra/plugin/apify/dataset/SaveDeprecationTest.java
+++ b/src/test/java/io/kestra/plugin/apify/dataset/SaveDeprecationTest.java
@@ -1,0 +1,13 @@
+package io.kestra.plugin.apify.dataset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SaveDeprecationTest {
+
+    @Test
+    void givenSaveClass_whenCheckingDeprecation_thenIsAnnotatedAsDeprecated() {
+        assertTrue(Save.class.isAnnotationPresent(Deprecated.class));
+    }
+}

--- a/src/test/java/io/kestra/plugin/apify/task/RunTest.java
+++ b/src/test/java/io/kestra/plugin/apify/task/RunTest.java
@@ -1,0 +1,43 @@
+package io.kestra.plugin.apify.task;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KestraTest
+class RunTest {
+
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void givenRequiredFields_whenBuildingTaskRun_thenBuildsSuccessfully() {
+        var taskRun = assertDoesNotThrow(() -> Run.builder()
+            .taskId(Property.ofValue("my_username~my-task"))
+            .apiToken(Property.ofValue("fake-token"))
+            .build());
+
+        assertNotNull(taskRun.getTaskId());
+    }
+
+    @Test
+    void givenTaskRunWithOptionalFields_whenBuildingTaskRun_thenBuildsSuccessfully() {
+        var taskRun = assertDoesNotThrow(() -> Run.builder()
+            .taskId(Property.ofValue("my_username~my-task"))
+            .apiToken(Property.ofValue("fake-token"))
+            .maxItems(Property.ofValue(100))
+            .waitForFinish(Property.ofValue(30))
+            .build());
+
+        assertNotNull(taskRun.getTaskId());
+        assertNotNull(taskRun.getMaxItems());
+        assertNotNull(taskRun.getWaitForFinish());
+    }
+}


### PR DESCRIPTION
fixes https://github.com/kestra-io/plugin-apify/issues/16

## Summary

- **Improvement 2**: `apiToken` is now marked with `format = "password"` in its `@Schema` annotation, so the Kestra UI masks the value instead of showing it in plain text.
- **Improvement 3**: `dataset.Save` is deprecated (actors automatically save their output to a dataset; use `dataset.Get` or `dataset.GetLastRun` instead). A new `task.Run` task is added to trigger Apify **Tasks** (actors with a predefined configuration) via `POST /v2/actor-tasks/{taskId}/runs`.
- **Improvement 4**: The `memory` field on both `actor.Run` and `task.Run` is now a `MemoryMbytes` enum (powers of two: 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768 MB), rendered as a select list in the UI.
- **Improvement 5**: Fields like `logLevel`, `allowFailure`, `disabled`, etc. are Kestra core `Task` properties — they cannot be removed from the plugin.
- **Improvement 6**: `waitForFinish` is now `Property<Integer>` (was `Property<Double>`) with a description capping it at 60 seconds.

> Improvement 1 (moving the `input` field out of optional properties) is handled by a separate PR.

## Test plan

- [ ] `./gradlew shadowJar` compiles cleanly
- [ ] `./gradlew test` all tests pass
- [ ] `apiToken` field renders as a masked password in the Kestra UI
- [ ] `actor.Run` `memory` renders as a dropdown with the 9 enum values
- [ ] `task.Run` successfully triggers an Apify Task and returns an `ActorRun` output
- [ ] `dataset.Save` still works but shows a deprecation warning