### PR TITLE
Documentation review: plugin-apify

### DIFF
--- a/src/main/java/io/kestra/plugin/apify/actor/Run.java
+++ b/src/main/java/io/kestra/plugin/apify/actor/Run.java
@@ -38,7 +38,7 @@ import lombok.experimental.SuperBuilder;
 @Plugin(
     examples = {
         @Example(
-            title = "Save dataset with given id as temp file.",
+            title = "Run an Apify actor with input.",
             full = true,
             code = """
                  id: run_actor

--- a/src/main/java/io/kestra/plugin/apify/dataset/Get.java
+++ b/src/main/java/io/kestra/plugin/apify/dataset/Get.java
@@ -56,9 +56,14 @@ import lombok.experimental.SuperBuilder;
                     clean: false
                     offset: 1
                     limit: 10
-                    fields: userId, #id, #createdAt, postMeta
-                    omit: #id
-                    flatten: postMeta
+                    fields:
+                      - userId
+                      - "#id"
+                      - "#createdAt"
+                      - postMeta
+                    omit:
+                      - "#id"
+                    flatten: true
                     sort: ASC
                     skipEmpty: false
                 """

--- a/src/main/java/io/kestra/plugin/apify/dataset/Save.java
+++ b/src/main/java/io/kestra/plugin/apify/dataset/Save.java
@@ -54,7 +54,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                 """
         ),
         @Example(
-            title = "Save dataset with given id as temp file.",
+            title = "Save a dataset as a CSV file.",
             full = true,
             code = """
                 id: save_data_set_to_csv_file
@@ -66,9 +66,14 @@ import io.kestra.core.models.annotations.PluginProperty;
                     apiToken: "{{ secret('APIFY_API_TOKEN') }}"
                     datasetId: RNtYOZmecGriFjtDH
                     format: CSV
-                    fields: userId, #id, #createdAt, postMeta
-                    omit: #id
-                    flatten: postMeta
+                    fields:
+                      - userId
+                      - "#id"
+                      - "#createdAt"
+                      - postMeta
+                    omit:
+                      - "#id"
+                    flatten: true
                     sort: ASC
                 """
         )

--- a/src/main/java/io/kestra/plugin/apify/package-info.java
+++ b/src/main/java/io/kestra/plugin/apify/package-info.java
@@ -1,6 +1,6 @@
 @PluginSubGroup(
-    title = "Example plugin",
-    description = "A plugin to show how to build a plugin in Kestra.",
+    title = "Apify",
+    description = "Tasks to orchestrate Apify Actors, saved Tasks, and datasets from Kestra.",
     categories = {
         PluginSubGroup.PluginCategory.DATA
     }

--- a/src/main/resources/doc/io.kestra.plugin.apify.md
+++ b/src/main/resources/doc/io.kestra.plugin.apify.md
@@ -14,4 +14,4 @@ Set `apiToken` (required) to your Apify API token. Store secrets in [secrets](ht
 
 `dataset.Get` retrieves items from an Apify dataset — set `datasetId` (required). Control the result with `offset` (default 0), `limit` (default 1000), `fields` / `omit` (field filter lists), `clean` (default `true`), `sort` (default `ASC`), `flatten`, `skipEmpty` (default `true`), `skipHidden` (default `false`), `simplified` (default `false`), and `skipFailedPages` (default `false`). The output includes `dataset` (list of items).
 
-`dataset.GetLastRun` retrieves the dataset from the last run of an actor — set `actorId` (required). Returns a full `ActorRun` object.
+`dataset.GetLastRun` retrieves the most recent run of an actor — set `actorId` (required). Returns a full `ActorRun` object (the run detail, including `defaultDatasetId` to fetch its dataset).


### PR DESCRIPTION
## Documentation review: plugin-apify

Documentation-only pass over all task classes (`actor.Run`, `task.Run`, `dataset.Get`,
`dataset.GetLastRun`, `dataset.Save`), the connection base, output POJOs, package-info subgroups,
the how-to doc, and metadata. Task inventory cross-checked against the Kestra plugin registry
(4 active tasks + deprecated `dataset.Save`, matches). No behavior, validation, or UI-layout changes.

5 files changed.

### Fixed — correctness
- **Root `package-info.java` was placeholder template text** — `title = "Example plugin"`,
  `description = "A plugin to show how to build a plugin in Kestra."` → real Apify subgroup text.
- **`actor.Run` example title** was copy-pasted from `dataset.Save` ("Save dataset with given id as
  a temp file") → "Run an Apify actor with input".
- **`dataset.Get` example (with options) was broken YAML:** `fields`/`omit` are `List<String>`
  properties but were written as comment-truncated scalars (`fields: userId, #id, ...` — the
  unquoted `#` starts a YAML comment), and `flatten` is a boolean but was set to `postMeta`.
  Rewritten as proper YAML lists with quoted `#`-prefixed field names and `flatten: true`.
- **doc `dataset.GetLastRun`** said it "retrieves the dataset from the last run" — it returns the
  run detail (`ActorRun`), not the dataset. Corrected.

### Fixed — deprecated task (same broken pattern)
- **`dataset.Save` example** had the same broken YAML (`fields`/`omit`/`flatten`) and both its
  examples shared one title. Fixed the YAML and retitled the CSV example. (`Save` is deprecated;
  fixed for consistency since it still ships.)

### ⚠️ Follow-up for engineering (not changed here)
- **`task.Run` sends the wrong `memory` value.** It passes the `MemoryMbytes` enum object as the
  query param (`...memory).as(MemoryMbytes.class)`), whereas `actor.Run` maps it via
  `MemoryMbytes::getValue`. The saved task run likely receives the enum name instead of the numeric
  MB value.
- **`dataset.GetLastRun` is packaged under `dataset`** but fetches an actor run (returns `ActorRun`)
  — arguably belongs in the `actor` subgroup.
